### PR TITLE
Add GitHub action for linting and formatting

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: action/checkout@v2
+      - uses: actions/checkout@v2
 
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,24 @@
+name: Check
+on:
+  push:
+    branches: [ github-action ]
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: action/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Check formatting
+        run: npm run format:check
+
+      - name: Check linting
+        run: npm run lint:check

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ const client = new Client({ intents: [Intents.FLAGS.GUILDS] });
 let textChannel: TextChannel;
 
 // TODO: this needs to be typed or changed overal, mainly used for caching data, this can be handlede in other ways
-let guildInfoMessage: string;
+let guildInfoMessage;
 
 client.once('ready', async () => {
   console.log('Ready');

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,12 +9,12 @@ const client = new Client({ intents: [Intents.FLAGS.GUILDS] });
 let textChannel: TextChannel;
 
 // TODO: this needs to be typed or changed overal, mainly used for caching data, this can be handlede in other ways
-let guildInfoMessage;
+let guildInfoMessage: string;
 
 client.once('ready', async () => {
   console.log('Ready');
   // Get right channel
-  const channel = client.channels.cache.get(config.guildWarsChannel);
+  const channel = client.channels.cache.get(config.guildWarsChannel)
   textChannel = channel as TextChannel;
 
   // Start Information Interval

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ let guildInfoMessage: string;
 client.once('ready', async () => {
   console.log('Ready');
   // Get right channel
-  const channel = client.channels.cache.get(config.guildWarsChannel)
+  const channel = client.channels.cache.get(config.guildWarsChannel);
   textChannel = channel as TextChannel;
 
   // Start Information Interval


### PR DESCRIPTION
To prevent introduction of later formatting linting errors, run a github action which checks it on every master push